### PR TITLE
Fixed IE compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
     "version": "1.8.0",
     "compilerOptions": {
         "outDir": "build/es5",
-        "target": "es6",
-        "lib": ["es6", "dom"],
-        "module": "es6",
+        "target": "es5",
+        "lib": ["es5", "dom"],
+        "module": "es5",
         "moduleResolution": "node",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
`class` isn't supported in IE11 yet (https://kangax.github.io/compat-table/es6/). I think will be better to use the ES5 target.