### PR TITLE
relaxing angular peer dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "zone.js": "^0.6.25"
   },
   "peerDependencies": {
-    "@angular/core": "2.0.0",
+    "@angular/core": "^2.0.0",
     "rxjs": "^5.0.0-beta.12"
   }
 }


### PR DESCRIPTION
Now npm won't warn that a dependency is not met when you use a more recent version of angular.